### PR TITLE
convert quotes, remove extra params

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
 $(document).ready(function() {
 
   // logic for adding an item to shopping list
-  $("#js-shopping-list-form").submit(function(event) {
+  $('#js-shopping-list-form').submit(function(event) {
     // stops default browser behavior for form submission,
     // since we don't actually want to submit to server
     event.preventDefault();
 
-    // add new item to botom of list
+    // add new item to bottom of list
     $('.shopping-list').append(
       '<li>' +
         '<span class="shopping-item">' + $("#shopping-list-entry").val() + '</span>' +
@@ -21,23 +21,22 @@ $(document).ready(function() {
       '</li>'
     );
     // remove the submitted item from the form input
-    $(this)[0].reset();
+    $(this)[0].reset(); 
   });
 
   // logic for deleting items from list
-  $(".shopping-list").on("click", ".shopping-item-delete", function(event){
+  $('.shopping-list').on('click', '.shopping-item-delete', function(){
     // here `this` refers to the `.shopping-item-delete` element that was clicked.
     // we travel up the document tree to get the nearest parent element
     // that"s an `li`
-    $(this).closest("li").remove();
+    $(this).closest('li').remove();
   });
 
   // logic for checking/unchecking items
-  $(".shopping-list").on("click", ".shopping-item-toggle", function(event){
+  $('.shopping-list').on('click', '.shopping-item-toggle', function(){
 
     // toggle the .shopping-item__checked class
-    $(this).closest("li").find(".shopping-item").toggleClass(
-      "shopping-item__checked");
+    $(this).closest('li').find('.shopping-item').toggleClass('shopping-item__checked');
   });
 
 })


### PR DESCRIPTION
using 2 different quotes is sloppy (and I yell at the students all the time for it). Switched to single. 
removed the extra event parameters. better not to create the extra room in memory for the unused vars
fixed typo in bottom
put toggleClass onto one line (idk, looks prettier)
